### PR TITLE
Use valid category in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -4,6 +4,6 @@ author=kerikun11
 maintainer=kerikun11 <kerikun11@gmail.com>
 sentence=ESP32 Time Library for Arduino
 paragraph=ESP32 Time Library for Arduino
-category=Time
+category=Timing
 url=https://github.com/kerikun11/ESP32Time
 architectures=esp32


### PR DESCRIPTION
The previous category value caused the warning:
```
WARNING: Category 'Time' in library ESP32Time is not valid. Setting to 'Uncategorized'
```
List of valid category values:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format